### PR TITLE
Start docker compose with image pull error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   web:
     build: .
@@ -13,20 +11,6 @@ services:
       - ./static/images:/root/static/images
       - ./static/videos:/root/static/videos
     restart: unless-stopped
-    networks:
-      - soma-network
-
-  # Optional: TinaCMS backend service
-  tina:
-    image: tinacms/tinacms:latest
-    ports:
-      - "4001:4001"
-    environment:
-      - TINA_PUBLIC_CLIENT_ID=your-client-id
-      - TINA_PUBLIC_BRANCH=main
-    volumes:
-      - ./content:/content
-      - ./tina:/tina
     networks:
       - soma-network
 


### PR DESCRIPTION
Remove obsolete `version` key and non-existent `tina` service from `docker-compose.yml` to fix image pull errors and warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-beaae8c1-6ec6-4039-815b-b75a7d6ecef3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-beaae8c1-6ec6-4039-815b-b75a7d6ecef3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

